### PR TITLE
Make the singularity screwdriver actually a screwdriver. Also it has a new ability

### DIFF
--- a/src/main/java/api/hbm/block/IOverfusable.java
+++ b/src/main/java/api/hbm/block/IOverfusable.java
@@ -1,0 +1,9 @@
+package api.hbm.block;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public interface IOverfusable {
+	boolean onOverfuse(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ItemStack item);
+}

--- a/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
+++ b/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import api.hbm.block.IOverfusable;
 import api.hbm.block.IToolable;
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ILookOverlay;
@@ -21,7 +22,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.Pre;
 import net.minecraftforge.common.util.ForgeDirection;
 
-public class HeaterElectric extends BlockDummyable implements ILookOverlay, ITooltipProvider, IToolable {
+public class HeaterElectric extends BlockDummyable implements ILookOverlay, ITooltipProvider, IToolable, IOverfusable {
 
 	public HeaterElectric() {
 		super(Material.iron);
@@ -29,13 +30,13 @@ public class HeaterElectric extends BlockDummyable implements ILookOverlay, IToo
 
 	@Override
 	public TileEntity createNewTileEntity(World world, int meta) {
-		
+
 		if(meta >= 12)
 			return new TileEntityHeaterElectric();
-		
+
 		if(hasExtra(meta))
 			return new TileEntityProxyCombo().power();
-		
+
 		return null;
 	}
 
@@ -62,47 +63,66 @@ public class HeaterElectric extends BlockDummyable implements ILookOverlay, IToo
 
 	@Override
 	public void printHook(Pre event, World world, int x, int y, int z) {
-		
+
 		int[] pos = this.findCore(world, x, y, z);
-		
+
 		if(pos == null)
 			return;
-		
+
 		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-		
+
 		if(!(te instanceof TileEntityHeaterElectric))
 			return;
-		
+
 		TileEntityHeaterElectric heater = (TileEntityHeaterElectric) te;
 
 		List<String> text = new ArrayList();
 		text.add(String.format(Locale.US, "%,d", heater.heatEnergy) + " TU");
 		text.add(EnumChatFormatting.GREEN + "-> " + EnumChatFormatting.RESET + heater.getConsumption() + " HE/t");
 		text.add(EnumChatFormatting.RED + "<- " + EnumChatFormatting.RESET + heater.getHeatGen() + " TU/t");
-		
+
 		ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getUnlocalizedName() + ".name"), 0xffff00, 0x404000, text);
 	}
 
 	@Override
 	public boolean onScrew(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ToolType tool) {
-		
+
 		if(tool != ToolType.SCREWDRIVER)
 			return false;
-		
+
 		if(world.isRemote) return true;
-		
+
 		int[] pos = this.findCore(world, x, y, z);
-		
+
 		if(pos == null) return false;
-		
+
 		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
-		
+
 		if(!(te instanceof TileEntityHeaterElectric)) return false;
-		
+
 		TileEntityHeaterElectric tile = (TileEntityHeaterElectric) te;
 		tile.toggleSetting();
 		tile.markDirty();
-		
+
+		return true;
+	}
+
+	@Override
+	public boolean onOverfuse(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ItemStack item) {
+		if(world.isRemote) return true;
+
+		int[] pos = this.findCore(world, x, y, z);
+
+		if(pos == null) return false;
+
+		TileEntity te = world.getTileEntity(pos[0], pos[1], pos[2]);
+
+		if(!(te instanceof TileEntityHeaterElectric)) return false;
+
+		TileEntityHeaterElectric tile = (TileEntityHeaterElectric) te;
+		tile.overfuse();
+		tile.markDirty();
+
 		return true;
 	}
 }

--- a/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
+++ b/src/main/java/com/hbm/blocks/machine/HeaterElectric.java
@@ -9,6 +9,7 @@ import api.hbm.block.IToolable;
 import com.hbm.blocks.BlockDummyable;
 import com.hbm.blocks.ILookOverlay;
 import com.hbm.blocks.ITooltipProvider;
+import com.hbm.config.ServerConfig;
 import com.hbm.tileentity.TileEntityProxyCombo;
 import com.hbm.tileentity.machine.TileEntityHeaterElectric;
 import com.hbm.util.i18n.I18nUtil;
@@ -110,6 +111,7 @@ public class HeaterElectric extends BlockDummyable implements ILookOverlay, IToo
 	@Override
 	public boolean onOverfuse(World world, EntityPlayer player, int x, int y, int z, int side, float fX, float fY, float fZ, ItemStack item) {
 		if(world.isRemote) return true;
+		if(!ServerConfig.Sk_overfuseHeater.get()) return false;
 
 		int[] pos = this.findCore(world, x, y, z);
 

--- a/src/main/java/com/hbm/config/ServerConfig.java
+++ b/src/main/java/com/hbm/config/ServerConfig.java
@@ -30,6 +30,7 @@ public class ServerConfig extends RunningConfig {
 	public static ConfigWrapper<Boolean> Sk_enableBaleSpread = new ConfigWrapper<>(true);
 	public static ConfigWrapper<Boolean> Sk_ultraAdvancedRemovalTools = new ConfigWrapper<>(false);
 	public static ConfigWrapper<Boolean> Sk_smartestSmartRod = new ConfigWrapper<>(false);
+	public static ConfigWrapper<Boolean> Sk_overfuseHeater = new ConfigWrapper<>(true);
 
 	private static void initDefaults() {
 		configMap.put("DAMAGE_COMPATIBILITY_MODE", DAMAGE_COMPATIBILITY_MODE);
@@ -52,6 +53,7 @@ public class ServerConfig extends RunningConfig {
 		configMap.put("Sk_enableBaleSpread", Sk_enableBaleSpread);
 		configMap.put("Sk_ultraAdvancedRemovalTools", Sk_ultraAdvancedRemovalTools);
 		configMap.put("Sk_smartestSmartRod", Sk_smartestSmartRod);
+		configMap.put("Sk_overfuseHeater",Sk_overfuseHeater);
 	}
 
 	/** Initializes defaults, then reads the config file if it exists, then writes the config file. */

--- a/src/main/java/com/hbm/handler/DecayConversions.java
+++ b/src/main/java/com/hbm/handler/DecayConversions.java
@@ -1,0 +1,58 @@
+package com.hbm.handler;
+
+import com.hbm.config.VersatileConfig;
+import com.hbm.items.ModItems;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.WeightedRandom;
+
+import javax.annotation.Nullable;
+import java.util.*;
+
+public class DecayConversions {
+	private static final Random rand = new Random();
+	private static final Map<Item,DecayStats> map = new IdentityHashMap<>();
+
+	public static void init(){
+		map.put(ModItems.ingot_au198,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 20F),new DecayResult(ModItems.ingot_mercury,1)));
+		map.put(ModItems.nugget_au198,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 100F),new DecayResult(ModItems.nugget_mercury,1)));
+		map.put(ModItems.ingot_pb209,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 10F),new DecayResult(ModItems.ingot_bismuth,1)));
+		map.put(ModItems.nugget_pb209,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 50F),new DecayResult(ModItems.nugget_bismuth,1)));
+		map.put(ModItems.powder_sr90,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 10F),new DecayResult(ModItems.powder_zirconium,1)));
+		map.put(ModItems.nugget_sr90,new DecayStats(1F/(VersatileConfig.getShortDecayChance() / 50F),new DecayResult(ModItems.nugget_zirconium,1)));
+	}
+
+	public static class DecayStats {
+		private List<DecayResult> options = new ArrayList<>();
+		private float decayChance;
+
+		public DecayStats(float decayChance, DecayResult... options) {
+			this.decayChance = decayChance;
+			this.options.addAll(Arrays.asList(options));
+		}
+
+		public @Nullable ItemStack tryDecay(){
+			if(rand.nextFloat() < decayChance){
+				return ((DecayResult)WeightedRandom.getRandomItem(rand,options)).result;
+			}
+			return null;
+		}
+	}
+
+	public static class DecayResult extends WeightedRandom.Item {
+		private final ItemStack result;
+
+		public DecayResult(ItemStack result, int weight) {
+			super(weight);
+			this.result = result;
+		}
+
+		public DecayResult(Item result, int weight) {
+			this(new ItemStack(result),weight);
+		}
+
+		public ItemStack getResult() {
+			return result;
+		}
+	}
+}

--- a/src/main/java/com/hbm/items/ModItems.java
+++ b/src/main/java/com/hbm/items/ModItems.java
@@ -4399,7 +4399,7 @@ public class ModItems {
 		blowtorch = new ItemBlowtorch().setUnlocalizedName("blowtorch");
 		acetylene_torch = new ItemBlowtorch().setUnlocalizedName("acetylene_torch");
 		boltgun = new ItemBoltgun().setUnlocalizedName("boltgun");
-		overfuse = new ItemCustomLore().setUnlocalizedName("overfuse").setMaxStackSize(1).setFull3D().setTextureName(RefStrings.MODID + ":overfuse");
+		overfuse = new ItemOverfuse().setUnlocalizedName("overfuse").setMaxStackSize(1).setFull3D().setTextureName(RefStrings.MODID + ":overfuse");
 		arc_electrode = new ItemArcElectrode().setUnlocalizedName("arc_electrode").setCreativeTab(MainRegistry.controlTab).setTextureName(RefStrings.MODID + ":arc_electrode");
 		arc_electrode_burnt = new ItemArcElectrodeBurnt().setUnlocalizedName("arc_electrode_burnt").setCreativeTab(MainRegistry.controlTab).setTextureName(RefStrings.MODID + ":arc_electrode_burnt");
 

--- a/src/main/java/com/hbm/items/tool/ItemOverfuse.java
+++ b/src/main/java/com/hbm/items/tool/ItemOverfuse.java
@@ -1,0 +1,26 @@
+package com.hbm.items.tool;
+
+import api.hbm.block.IOverfusable;
+import api.hbm.block.IToolable;
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+public class ItemOverfuse extends ItemTooling {
+	public ItemOverfuse() {
+		super(IToolable.ToolType.SCREWDRIVER, 0);
+	}
+
+	@Override
+	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float fX, float fY, float fZ) {
+		Block b = world.getBlock(x, y, z);
+
+		if(b instanceof IOverfusable) {
+			if (((IOverfusable) b).onOverfuse(world, player, x, y, z, side, fX, fY, fZ, stack)) {
+				return true;
+			}
+		}
+		return super.onItemUse(stack,player,world,x,y,z,side,fX,fY,fZ);
+	}
+}

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -14,6 +14,7 @@ import com.hbm.entity.logic.IChunkLoader;
 import com.hbm.entity.mob.siege.SiegeTier;
 import com.hbm.handler.*;
 import com.hbm.handler.atmosphere.ChunkAtmosphereManager;
+import com.hbm.handler.DecayConversions;
 import com.hbm.handler.imc.IMCBlastFurnace;
 import com.hbm.handler.imc.IMCCentrifuge;
 import com.hbm.handler.imc.IMCCrystallizer;
@@ -316,6 +317,8 @@ public class MainRegistry {
 		MinecraftForge.EVENT_BUS.register(oreMan); //OreRegisterEvent
 		OreDictManager.registerGroups(); //important to run first
 		OreDictManager.registerOres();
+
+		DecayConversions.init();
 
 		if(WorldConfig.enableCraterBiomes) BiomeGenCraterBase.initDictionary();
 		//BiomeGenNoMansLand.initDictionary();

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterElectric.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityHeaterElectric.java
@@ -228,4 +228,11 @@ public class TileEntityHeaterElectric extends TileEntityLoadedBase implements IH
 	public void pasteSettings(NBTTagCompound nbt, int index, World world, EntityPlayer player, int x, int y, int z) {
 		this.setting = nbt.getInteger("setting");
 	}
+
+	public void overfuse() {
+		setting++;
+
+		if(setting > 20)
+			setting = 0;
+	}
 }


### PR DESCRIPTION
Its funny that the singularity screwdriver is not actually a screwdriver in code, and also is referenced as "overfuse".

So I made it a screwdriver and also gave it the "overfuse" ability. Overfuse currently only applies to electric heaters and allows them to output 2 times the normal amount of maximum heat at a significant power cost. Its probably best to just use two heaters but I figure the screwdriver should live up to its "overfuse" name.

Also there is a config option to disable this, its set to true by default.